### PR TITLE
Add charmcraft.yaml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
           sudo snap install charmcraft --classic
       - name: Build charm
         run: |
-          if ! charmcraft build; then
+          if ! charmcraft pack --destructive-mode; then
             echo Build failed, full log:
             cat "$(ls -1t "$HOME"/snap/charmcraft/common/charmcraft-log-* | head -n1)"
             exit 1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           python-version: '3.8'
       - name: Install Dependencies
         run: |
-          sudo snap install charmcraft --beta
+          sudo snap install charmcraft --classic
       - name: Build charm
         run: |
           if ! charmcraft build; then

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ via Juju.
 Build the charm with [charmcraft][]:
 
 ```
-charmcraft build
+charmcraft pack
 ```
 
 ### Testing

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -1,0 +1,4 @@
+type: charm
+bases:
+- name: ubuntu
+  channel: "20.04"


### PR DESCRIPTION
Fixes build failures with Charmcraft 1.5.0. `charmcraft.yaml` is required now.