### PR TITLE
Update image-registry default to ghcr.io/canonical/cdk

### DIFF
--- a/.github/workflows/vsphere-integration.yaml
+++ b/.github/workflows/vsphere-integration.yaml
@@ -20,7 +20,7 @@ jobs:
           credentials-yaml: ${{ secrets.CREDENTIALS_YAML }}
           clouds-yaml: ${{ secrets.CLOUDS_YAML }}
           bootstrap-constraints: "arch=amd64 cores=2 mem=4G"
-          bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=rocks.canonical.com/cdk/jujusolutions"
+          bootstrap-options: "${{ secrets.FOCAL_BOOTSTRAP_OPTIONS }} --model-default datastore=vsanDatastore --model-default primary-network=VLAN_2763 --config caas-image-repo=ghcr.io/canonical/cdk/jujusolutions"
       - name: Run test
         run: tox -e integration
       - name: Setup Debug Artifact Collection

--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 options:
   image-registry:
     type: string
-    default: rocks.canonical.com:443/cdk
+    default: ghcr.io/canonical/cdk
     description: |
       Container image registry for sriov-network-device-plugin
   log-level:


### PR DESCRIPTION
`rocks.canonical.com` is being retired. This PR updates the image registry
references from the legacy registry to the new GitHub Container Registry.

**Changes:**
- `rocks.canonical.com:443/cdk` → `ghcr.io/canonical/cdk`
- `rocks.canonical.com/cdk` → `ghcr.io/canonical/cdk`
